### PR TITLE
Homework 3, Networks, Canary ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ SergeSpinoza Platform repository
 - Создали манифест сервиса с ClusterIP web-svc-cip;
 - Переключили kube-proxy в режим `ipvs`; 
 - Очистили правила iptables в minikube от мусора; 
-- Настроили работу с MetalLB (к сожалению в macos доступ через браузер получить не удалось даже с пропианным маршрутом и драйвером hyperkit);
+- Настроили работу с MetalLB (к сожалению в macos доступ через браузер получить не удалось даже с прописанным маршрутом и драйвером hyperkit);
 - Установили и настроили работу ingress-nginx; 
 
 ### Задание со * 
@@ -85,7 +85,7 @@ Address 1: 172.17.0.7 172-17-0-7.web-svc.default.svc.cluster.local
 Address 2: 172.17.0.9 172-17-0-9.web-svc.default.svc.cluster.local
 Address 3: 172.17.0.8 172-17-0-8.web-svc.default.svc.cluster.local
 ```
-- Добавлен доступ к kubernetes-dashboard через настроенный ingress-proxy (манифес добавлен в файл `web-ingress.yaml`);
+- Добавлен доступ к kubernetes-dashboard через настроенный ingress-proxy (манифест добавлен в файл `web-ingress.yaml`);
 - Реализовано канареечное развертывание, манифесты `canary-namespaces.yaml` и `canary-ingress.yaml`. 
 
 ### Развертывание и проверка канареечного развертывания: 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ SergeSpinoza Platform repository
 ## Оглавление
 1. [Домашнее задание №1, Minikube](#домашнее-задание-1)
 2. [Домашнее задание №2, RBAC](#домашнее-задание-2)
+3. [Домашнее задание №3, Сети](#домашнее-задание-3)
 
 <br><br>
 ## Домашнее задание 1
@@ -58,4 +59,92 @@ SergeSpinoza Platform repository
 ### Полезное
 Команды: 
 - `kubectl auth can-i get/create ...` - проверка прав/возможности создания (пример `kubectl auth can-i get deployments --as system:serviceaccount:dev:ken -n dev`, `kubectl auth can-i create deployments --as system:serviceaccount:dev:ken -n dev`).
+
+
+<br><br>
+## Домашнее задание 3
+### Выполнено
+- Добавили к ранее созданному манифесту web-pod.yaml readinessProbe и livenessProbe;
+- Создали манифест deployment с указанием стратегии обновления;
+- Создали манифест сервиса с ClusterIP web-svc-cip;
+- Переключили kube-proxy в режим `ipvs`; 
+- Очистили правила iptables в minikube от мусора; 
+- Настроили работу с MetalLB (к сожалению в macos доступ через браузер получить не удалось даже с пропианным маршрутом и драйвером hyperkit);
+- Установили и настроили работу ingress-nginx; 
+
+### Задание со * 
+- Настроен LoadBalancer для CoreDNS (kube-dns) для 53 TCP и UDP портов с одинаковым внешним ip. Для проверки необходимо применить манифест `kubectl apply -f coredns-svc-lb.yaml` и проверить, выполнив команду из ssh minikube, например (c выводом):
+
+```
+# nslookup web-svc.default.svc.cluster.local 172.17.255.3
+Server:    172.17.255.3
+Address 1: 172.17.255.3 coredns-svc-lb-tcp.kube-system.svc.cluster.local
+
+Name:      web-svc.default.svc.cluster.local
+Address 1: 172.17.0.7 172-17-0-7.web-svc.default.svc.cluster.local
+Address 2: 172.17.0.9 172-17-0-9.web-svc.default.svc.cluster.local
+Address 3: 172.17.0.8 172-17-0-8.web-svc.default.svc.cluster.local
+```
+- Добавлен доступ к kubernetes-dashboard через настроенный ingress-proxy (манифес добавлен в файл `web-ingress.yaml`);
+- Реализовано канареечное развертывание, манифесты `canary-namespaces.yaml` и `canary-ingress.yaml`. 
+
+### Развертывание и проверка канареечного развертывания: 
+- Применить манифест `kubectl apply -f canary-namespaces.yaml`, который создаст необходимые namespace;
+- Развернуть приложение production `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/docs/examples/http-svc.yaml -n echo-production`; 
+- Развернуть "тестовое" приложение `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/docs/examples/http-svc.yaml -n echo-canary`;
+- Применить манифест `kubectl apply -f canary-ingress.yaml` для создания ingress для канареечного развертывания;
+- Узнать ip minikube, выполнив команду `minikube ip`;
+- Прописать в /etc/hosts следующую строчку: `<minikube_ip> echo.com`
+- Проверить работу следующим образом: 
+  - Через браузер зайти на сайт http://echo.com, обратить внимание, что строка `pod namespace:` имеет значение: `echo-production`; 
+  - С помощью плагина ModHeader для браузера googleChome (ссылка https://chrome.google.com/webstore/detail/modheader/idgpnmonknjnojddfkpgkljpfnnfcklj?hl=ru) добавить заголовок `CanaryByHeader` со значением `DoCanary` и обновить страницу;
+  - После этого строка `pod namespace:`должна изменить значение на: `echo-canary`.
+
+
+### Ответы на вопросы
+1. Почему следующая конфигурация валидна, но не имеет смысла?
+
+```
+livenessProbe:
+  exec:
+   command:
+     - 'sh'
+     - '-c'
+     - 'ps aux | grep my_web_server_process'
+```
+
+**Ответ:** потому что данная проверка всегда будет отдавать процесс самой команды grep. Чтобы эта проверка работала - надо исключить из результатов grep - например так:
+
+```
+livenessProbe:
+  exec:
+   command:
+     - 'sh'
+     - '-c'
+     - 'ps aux | grep -v grep | grep my_web_server_process'
+```
+
+2. Бывают ли ситуации, когда она все-таки имеет смысл?
+**Ответ:** если исключать в выводе процесс самой команды grep - то это ситуации когда процесс только делает что-то внутри контейнера (допустим пишет что-то в файле на persistent volume) и не слушает никакой tcp/udp порт (т.е. проверить этот сервис по сети не возможно). 
+
+3. Попробуйте разные варианты деплоя с крайними значениями maxSurge и maxUnavailable (оба 0, оба 100%, 0 и 100%)
+**Ответ:** если maxSurge и maxUnavailable выставить в 0 - то получаем ошибку невозможности выполнения деплоя, вида 
+```
+The Deployment "web" is invalid: spec.strategy.rollingUpdate.maxUnavailable: Invalid value: intstr.IntOrString{Type:0, IntVal:0, StrVal:""}: may not be 0 when `maxSurge` is 0
+```
+При других вариантах все работает корректно, т.к. maxUnavailable задает максимальное количество недоступных подов при обновлении, а maxSurge - превышение количества подов при обновлении от заданного в `replicas`;
+
+
+### Полезное
+Команды: 
+- `kubectl apply -f web-pod.yaml --force` - принудительное обновление;
+- `kubectl --namespace kube-system edit configmap/kube-proxy` - редактирование конфига kube-proxy (для включения ipvs - выставить `mode` в `ipvs`); 
+- `minikube ssh` - зайти в ssh minikube;
+- `iptables --list -nv -t nat` - показать nat правила iptables;
+- Внутри ssh minikube команда `toolbox` - запустить и зайти в контейнер с Fedora;
+  - `dnf install -y ipvsadm && dnf clean all` - установка ipvsadm внутри контейнера Fedora;
+  - `ipvsadm --list -n` - список правил ipvs;
+- `kubectl apply -f https://raw.githubusercontent.com/google/metallb/v0.8.0/manifests/metallb.yaml` - установка MetalLb;
+- `kubectl --namespace metallb-system logs controller-xxxxxxxxxxx-xxxxx` - логи контроллера MetalLB
+- `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/mandatory.yaml` или `minikube addons enable ingress` - установка ingress-nginx;
 

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -8,6 +8,12 @@ spec:
   containers:
   - name: web
     image: s1spinoza/k8s-httpserver-8000:latest
+    readinessProbe: # Добавим проверку готовности
+      httpGet: # веб-сервера отдавать
+        path: /index.html # контент
+        port: 80
+    livenessProbe:
+      tcpSocket: { port: 8000 }
     volumeMounts:
     - name: app
       mountPath: /app

--- a/kubernetes-networks/canary-ingress.yaml
+++ b/kubernetes-networks/canary-ingress.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: http-svc
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  namespace: echo-production
+spec:
+  rules:
+  - host: echo.com
+    http:
+      paths:
+      - backend:
+          serviceName: http-svc
+          servicePort: 80
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: http-svc
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-by-header: "CanaryByHeader"
+    nginx.ingress.kubernetes.io/canary-by-header-value: "DoCanary"
+  namespace: echo-canary
+spec:
+  rules:
+  - host: echo.com
+    http:
+      paths:
+      - backend:
+          serviceName: http-svc
+          servicePort: 80
+

--- a/kubernetes-networks/canary-namespaces.yaml
+++ b/kubernetes-networks/canary-namespaces.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+   name: echo-production
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+   name: echo-canary
+

--- a/kubernetes-networks/coredns-svc-lb.yaml
+++ b/kubernetes-networks/coredns-svc-lb.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-svc-lb-udp
+  annotations:
+    metallb.universe.tf/allow-shared-ip: coredns
+  namespace: kube-system
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  ports:
+  - protocol: UDP
+    port: 53
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-svc-lb-tcp
+  annotations:
+    metallb.universe.tf/allow-shared-ip: coredns
+  namespace: kube-system
+spec:
+  selector:
+    k8s-app: kube-dns
+  type: LoadBalancer
+  ports:
+  - protocol: TCP
+    port: 53
+

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+      - name: default
+        protocol: layer2
+        addresses:
+          - 172.17.255.1-172.17.255.255 
+

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,23 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+    - name: https
+      port: 443
+      targetPort: https
+

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web # Название нашего объекта Deployment
+spec:
+  replicas: 3 # Начнем с одного пода
+  selector: # Укажем, какие поды относятся к нашему Deployment:
+    matchLabels: # - это поды с меткой
+      app: web # app и ее значением web
+  template: # Теперь зададим шаблон конфигурации пода
+    metadata:
+      name: web
+      labels:
+        app: web
+    spec:
+      containers:
+      - name: web
+        image: s1spinoza/k8s-httpserver-8000:latest
+        livenessProbe:
+          tcpSocket: 
+            port: 8000
+        readinessProbe: # Добавим проверку готовности
+          httpGet: # веб-сервера отдавать
+            path: /index.html # контент
+            port: 8000
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      initContainers:
+      - name: init-web
+        image: busybox:1.31.0
+        command: ['sh', '-c', 'wget -O- https://raw.githubusercontent.com/express42/otus-platform-snippets/master/Module-02/Introduction-to-Kubernetes/wget.sh | sh']
+        volumeMounts:
+        - name: app
+          mountPath: /app
+      volumes:
+      - name: app
+        emptyDir: {}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 100%
+      maxSurge: 0

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /web
+        backend:
+          serviceName: web-svc
+          servicePort: 8000
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: dashboard
+  annotations:
+    nginx.ingress.kubernetes.io/secure-backends: "true"
+    nginx.ingress.kubernetes.io/add-base-url: "true"
+    # nginx.ingress.kubernetes.io/rewrite-target: "/"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    # nginx.ingress.kubernetes.io/configuration-snippet: rewrite ^(/dashboard)$ $1/ permanent;
+  namespace: kube-system
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /dashboard(/|$)(.*)
+        backend: 
+          serviceName: kubernetes-dashboard
+          servicePort: 80
+

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+


### PR DESCRIPTION
# Выполнено ДЗ №3

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 ### Выполнено
- Добавили к ранее созданному манифесту web-pod.yaml readinessProbe и livenessProbe;
- Создали манифест deployment с указанием стратегии обновления;
- Создали манифест сервиса с ClusterIP web-svc-cip;
- Переключили kube-proxy в режим `ipvs`; 
- Очистили правила iptables в minikube от мусора; 
- Настроили работу с MetalLB (к сожалению в macos доступ через браузер получить не удалось даже с прописанным маршрутом и драйвером hyperkit);
- Установили и настроили работу ingress-nginx; 

### Задание со * 
- Настроен LoadBalancer для CoreDNS (kube-dns) для 53 TCP и UDP портов с одинаковым внешним ip. Для проверки необходимо применить манифест `kubectl apply -f coredns-svc-lb.yaml` и проверить, выполнив команду из ssh minikube, например (c выводом):

```
# nslookup web-svc.default.svc.cluster.local 172.17.255.3
Server:    172.17.255.3
Address 1: 172.17.255.3 coredns-svc-lb-tcp.kube-system.svc.cluster.local

Name:      web-svc.default.svc.cluster.local
Address 1: 172.17.0.7 172-17-0-7.web-svc.default.svc.cluster.local
Address 2: 172.17.0.9 172-17-0-9.web-svc.default.svc.cluster.local
Address 3: 172.17.0.8 172-17-0-8.web-svc.default.svc.cluster.local
```
- Добавлен доступ к kubernetes-dashboard через настроенный ingress-proxy (манифест добавлен в файл `web-ingress.yaml`);
- Реализовано канареечное развертывание, манифесты `canary-namespaces.yaml` и `canary-ingress.yaml`. 

### Развертывание и проверка канареечного развертывания: 
- Применить манифест `kubectl apply -f canary-namespaces.yaml`, который создаст необходимые namespace;
- Развернуть приложение production `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/docs/examples/http-svc.yaml -n echo-production`; 
- Развернуть "тестовое" приложение `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/docs/examples/http-svc.yaml -n echo-canary`;
- Применить манифест `kubectl apply -f canary-ingress.yaml` для создания ingress для канареечного развертывания;
- Узнать ip minikube, выполнив команду `minikube ip`;
- Прописать в /etc/hosts следующую строчку: `<minikube_ip> echo.com`
- Проверить работу следующим образом: 
  - Через браузер зайти на сайт http://echo.com, обратить внимание, что строка `pod namespace:` имеет значение: `echo-production`; 
  - С помощью плагина ModHeader для браузера googleChome (ссылка https://chrome.google.com/webstore/detail/modheader/idgpnmonknjnojddfkpgkljpfnnfcklj?hl=ru) добавить заголовок `CanaryByHeader` со значением `DoCanary` и обновить страницу;
  - После этого строка `pod namespace:`должна изменить значение на: `echo-canary`.


### Ответы на вопросы
1. Почему следующая конфигурация валидна, но не имеет смысла?

```
livenessProbe:
  exec:
   command:
     - 'sh'
     - '-c'
     - 'ps aux | grep my_web_server_process'
```

**Ответ:** потому что данная проверка всегда будет отдавать процесс самой команды grep. Чтобы эта проверка работала - надо исключить из результатов grep - например так:

```
livenessProbe:
  exec:
   command:
     - 'sh'
     - '-c'
     - 'ps aux | grep -v grep | grep my_web_server_process'
```

2. Бывают ли ситуации, когда она все-таки имеет смысл?
**Ответ:** если исключать в выводе процесс самой команды grep - то это ситуации когда процесс только делает что-то внутри контейнера (допустим пишет что-то в файле на persistent volume) и не слушает никакой tcp/udp порт (т.е. проверить этот сервис по сети не возможно). 

3. Попробуйте разные варианты деплоя с крайними значениями maxSurge и maxUnavailable (оба 0, оба 100%, 0 и 100%)
**Ответ:** если maxSurge и maxUnavailable выставить в 0 - то получаем ошибку невозможности выполнения деплоя, вида 
```
The Deployment "web" is invalid: spec.strategy.rollingUpdate.maxUnavailable: Invalid value: intstr.IntOrString{Type:0, IntVal:0, StrVal:""}: may not be 0 when `maxSurge` is 0
```
При других вариантах все работает корректно, т.к. maxUnavailable задает максимальное количество недоступных подов при обновлении, а maxSurge - превышение количества подов при обновлении от заданного в `replicas`;
## PR checklist:
 - [x] Выставлен label с номером домашнего задания

